### PR TITLE
api: set content-type on heartbeat

### DIFF
--- a/api/heartbeat.cpp
+++ b/api/heartbeat.cpp
@@ -15,7 +15,8 @@ void send_heartbeat() {
     int status;
     char *buffer;
     size_t buffer_size = get_buffered_log(&buffer);
-    status = HTTP.PUT(url, buffer, buffer_size, "", resp, sizeof(resp));
+    string headers = "Content-Type: text/plain;\r\n";
+    status = HTTP.PUT(url, buffer, buffer_size, headers, resp, sizeof(resp));
 
     if (status != 200) {
         Logging.errorlnf("heartbeat error: server returned %d", status);


### PR DESCRIPTION
It caused an error on the rails app to send a request which contains no headers.

<details>
Started PUT "/api/devices/XXXXXX/heartbeat?status=running" for 127.0.0.1 at 2016-11-16 17:19:27 +0900

NoMethodError (undefined method `symbol' for nil:NilClass):

actionpack (5.0.0.1) lib/action_dispatch/http/parameters.rb:63:in `parse_formatted_parameters'
actionpack (5.0.0.1) lib/action_dispatch/http/request.rb:366:in `block in POST'
rack (2.0.1) lib/rack/request.rb:57:in `fetch'
rack (2.0.1) lib/rack/request.rb:57:in `fetch_header'
actionpack (5.0.0.1) lib/action_dispatch/http/request.rb:365:in `POST'
actionpack (5.0.0.1) lib/action_dispatch/http/parameters.rb:35:in `parameters'
actionpack (5.0.0.1) lib/action_dispatch/http/filter_parameters.rb:41:in `filtered_parameters'
actionpack (5.0.0.1) lib/action_controller/metal/instrumentation.rb:21:in `process_action'
actionpack (5.0.0.1) lib/action_controller/metal/params_wrapper.rb:248:in `process_action'
activerecord (5.0.0.1) lib/active_record/railties/controller_runtime.rb:18:in`process_action'
actionpack (5.0.0.1) lib/abstract_controller/base.rb:126:in `process'
actionpack (5.0.0.1) lib/action_controller/metal.rb:190:in `dispatch'
actionpack (5.0.0.1) lib/action_controller/metal.rb:262:in `dispatch'
actionpack (5.0.0.1) lib/action_dispatch/routing/route_set.rb:50:in `dispatch'
actionpack (5.0.0.1) lib/action_dispatch/routing/route_set.rb:32:in `serve'
actionpack (5.0.0.1) lib/action_dispatch/journey/router.rb:39:in `block in serve'
actionpack (5.0.0.1) lib/action_dispatch/journey/router.rb:26:in `each'
actionpack (5.0.0.1) lib/action_dispatch/journey/router.rb:26:in `serve'
actionpack (5.0.0.1) lib/action_dispatch/routing/route_set.rb:725:in `call'
rack (2.0.1) lib/rack/content_length.rb:15:in `call'
warden (1.2.6) lib/warden/manager.rb:35:in `block in call'
warden (1.2.6) lib/warden/manager.rb:34:in `catch'
warden (1.2.6) lib/warden/manager.rb:34:in `call'
rack (2.0.1) lib/rack/etag.rb:25:in `call'
rack (2.0.1) lib/rack/conditional_get.rb:38:in `call'
rack (2.0.1) lib/rack/head.rb:12:in `call'
activerecord (5.0.0.1) lib/active_record/migration.rb:552:in `call'
actionpack (5.0.0.1) lib/action_dispatch/middleware/callbacks.rb:38:in `blockin call'
activesupport (5.0.0.1) lib/active_support/callbacks.rb:97:in `__run_callbacks__'
activesupport (5.0.0.1) lib/active_support/callbacks.rb:750:in `_run_call_callbacks'
activesupport (5.0.0.1) lib/active_support/callbacks.rb:90:in `run_callbacks'
actionpack (5.0.0.1) lib/action_dispatch/middleware/callbacks.rb:36:in `call'
actionpack (5.0.0.1) lib/action_dispatch/middleware/executor.rb:12:in `call'
actionpack (5.0.0.1) lib/action_dispatch/middleware/remote_ip.rb:79:in `call'
actionpack (5.0.0.1) lib/action_dispatch/middleware/debug_exceptions.rb:49:in`call'
actionpack (5.0.0.1) lib/action_dispatch/middleware/show_exceptions.rb:31:in `call'
railties (5.0.0.1) lib/rails/rack/logger.rb:36:in `call_app'
railties (5.0.0.1) lib/rails/rack/logger.rb:24:in `block in call'
activesupport (5.0.0.1) lib/active_support/tagged_logging.rb:70:in `block in tagged'
activesupport (5.0.0.1) lib/active_support/tagged_logging.rb:26:in `tagged'
activesupport (5.0.0.1) lib/active_support/tagged_logging.rb:70:in `tagged'
railties (5.0.0.1) lib/rails/rack/logger.rb:24:in `call'
actionpack (5.0.0.1) lib/action_dispatch/middleware/request_id.rb:24:in `call'
rack (2.0.1) lib/rack/runtime.rb:22:in `call'
activesupport (5.0.0.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
actionpack (5.0.0.1) lib/action_dispatch/middleware/executor.rb:12:in `call'
actionpack (5.0.0.1) lib/action_dispatch/middleware/static.rb:136:in `call'
rack (2.0.1) lib/rack/sendfile.rb:111:in `call'
railties (5.0.0.1) lib/rails/engine.rb:522:in `call'
puma (3.6.0) lib/puma/configuration.rb:225:in `call'
puma (3.6.0) lib/puma/server.rb:578:in `handle_request'
puma (3.6.0) lib/puma/server.rb:415:in `process_client'
puma (3.6.0) lib/puma/server.rb:275:in `block in run'
puma (3.6.0) lib/puma/thread_pool.rb:116:in `block in spawn_thread'
Error during failsafe response: undefined method `symbol' for nil:NilClass
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/http/parameters.rb:63:in `parse_formatted_parameters'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/http/request.rb:366:in `block in POST'
  /home/dev/.bundle/gems/rack-2.0.1/lib/rack/request.rb:57:in `fetch'
  /home/dev/.bundle/gems/rack-2.0.1/lib/rack/request.rb:57:in `fetch_header'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/http/request.rb:365:in `POST'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/http/parameters.rb:35:in `parameters'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/http/mime_negotiation.rb:63:in `block in formats'
  /home/dev/.bundle/gems/rack-2.0.1/lib/rack/request.rb:57:in `fetch'
  /home/dev/.bundle/gems/rack-2.0.1/lib/rack/request.rb:57:in `fetch_header'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/http/mime_negotiation.rb:61:in `formats'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/public_exceptions.rb:22:in `call'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/show_exceptions.rb:49:in `render_exception'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/show_exceptions.rb:34:in `rescue in call'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  /home/dev/.bundle/gems/railties-5.0.0.1/lib/rails/rack/logger.rb:36:in `call_app'
  /home/dev/.bundle/gems/railties-5.0.0.1/lib/rails/rack/logger.rb:24:in `block in call'
  /home/dev/.bundle/gems/activesupport-5.0.0.1/lib/active_support/tagged_logging.rb:70:in `block in tagged'
  /home/dev/.bundle/gems/activesupport-5.0.0.1/lib/active_support/tagged_logging.rb:26:in `tagged'
  /home/dev/.bundle/gems/activesupport-5.0.0.1/lib/active_support/tagged_logging.rb:70:in `tagged'
  /home/dev/.bundle/gems/railties-5.0.0.1/lib/rails/rack/logger.rb:24:in `call'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/request_id.rb:24:in `call'
  /home/dev/.bundle/gems/rack-2.0.1/lib/rack/runtime.rb:22:in `call'
  /home/dev/.bundle/gems/activesupport-5.0.0.1/lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/executor.rb:12:in `call'
  /home/dev/.bundle/gems/actionpack-5.0.0.1/lib/action_dispatch/middleware/static.rb:136:in `call'
  /home/dev/.bundle/gems/rack-2.0.1/lib/rack/sendfile.rb:111:in `call'
  /home/dev/.bundle/gems/railties-5.0.0.1/lib/rails/engine.rb:522:in `call'
  /home/dev/.bundle/gems/puma-3.6.0/lib/puma/configuration.rb:225:in `call'
  /home/dev/.bundle/gems/puma-3.6.0/lib/puma/server.rb:578:in `handle_request'
  /home/dev/.bundle/gems/puma-3.6.0/lib/puma/server.rb:415:in `process_client'
  /home/dev/.bundle/gems/puma-3.6.0/lib/puma/server.rb:275:in `block in run'
  /home/dev/.bundle/gems/puma-3.6.0/lib/puma/thread_pool.rb:116:in `block in spawn_thread'
</details>